### PR TITLE
update to new smart contract gov proposal format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          provenance_version: "v1.13.0"
+          provenance_version: "v1.14.1"
           test_script: "./smart-contract-action/test/test.sh"
           generate_proposals: true
           wasm_path: "./smart-contract-action/test/provwasm_tutorial.wasm"
@@ -40,7 +40,7 @@ jobs:
         uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          provenance_version: "v1.13.0"
+          provenance_version: "v1.14.1"
           generate_proposals: true
           wasm_path: "./smart-contract-action/test/provwasm_tutorial.wasm"
 
@@ -54,7 +54,7 @@ jobs:
         uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          provenance_version: "v1.13.0"
+          provenance_version: "v1.14.1"
           init_data: "./smart-contract-action/test/init_data"
           generate_proposals: true
           wasm_path: "./smart-contract-action/test/provwasm_tutorial.wasm"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test with provenance release with proposals
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Smart Contract Action
         uses: ./
         with:
@@ -35,7 +35,7 @@ jobs:
     name: Test with provenance release without proposals
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Smart Contract Action
         uses: ./
         with:
@@ -49,7 +49,7 @@ jobs:
     name: Test with provenance release without proposals
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Smart Contract Action
         uses: ./
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog for Provenance Testing Action
 
 ## Unreleased changes
+* Update to new smart contract governance proposal format ([#7](https://github.com/provenance-io/provenance-testing-action/issues/7))
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ For an example of this in use look at [this repository's test workflow](https://
 - #### With a released version of Provenance
     ```yaml
     - name: Smart Contract Test setup
-        uses: provenance-io/provenance-testing-action@v1.1.1
+        uses: provenance-io/provenance-testing-action@v1.1.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          provenance_version: "v1.13.0"
+          provenance_version: "v1.14.1"
           test_script: "./scripts/name_test.sh"
     ```
 
@@ -25,7 +25,7 @@ For an example of this in use look at [this repository's test workflow](https://
     Note: `provenance_version` is a branch which has an associated `Pull Request` and a **successful** run of the [Provenance Build and Release action](https://github.com/provenance-io/provenance/actions/workflows/release.yml)
     ```yaml
     - name: Smart Contract Test setup
-        uses: provenance-io/provenance-testing-action@v1.1.1
+        uses: provenance-io/provenance-testing-action@v1.1.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           provenance_version: "issue/new-feature"
@@ -35,10 +35,10 @@ For an example of this in use look at [this repository's test workflow](https://
 #### Generating governance proposals
 ```yaml
 - name: Smart Contract Test setup
-    uses: provenance-io/provenance-testing-action@v1.1.1
+    uses: provenance-io/provenance-testing-action@v1.1.2
     with:
       github_token: ${{ secrets.GITHUB_TOKEN }}
-      provenance_version: "v1.13.0"
+      provenance_version: "v1.14.1"
       test_script: "./scripts/name_test.sh"
       generate_proposals: true
 ```
@@ -46,10 +46,10 @@ For an example of this in use look at [this repository's test workflow](https://
 #### Using provided initial data for Provenance
 ```yaml
 - name: Smart Contract Test setup
-    uses: provenance-io/provenance-testing-action@v1.1.1
+    uses: provenance-io/provenance-testing-action@v1.1.2
     with:
       github_token: ${{ secrets.GITHUB_TOKEN }}
-      provenance_version: "v1.13.0"
+      provenance_version: "v1.14.1"
       init_data: "./smart_contract_action/test/init_data"
       test_script: "./smart_contract_action/scripts/name_test.sh"
       generate_proposals: true
@@ -57,7 +57,7 @@ For an example of this in use look at [this repository's test workflow](https://
 
 After a successful run, the proposals will be added to an archive named `$GITHUB_JOB_proposals.zip` and attached to the build.
 
-**IMPORTANT**: The json proposals have placeholders for user-specific data (e.g., title, account addresses, code_id). These placeholders must be replaced in order to submit the proposal.
+**IMPORTANT**: The json proposals have placeholders for user-specific data (e.g., title, account addresses, code_id). These placeholders must be replaced in order to submit the proposal. This includes either placing the metadata contents directly into the proposal json (on-chain storage) or storing the metadata on IPFS and updating the `CID` in the proposal json.
 
 ---
 

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,4 @@ runs:
       with:
         name: ${{ github.job }}_proposals.zip
         path: |
-          wasm-store-proposal.json
-          instantiate-contract-proposal.json
-          migrate-contract-proposal.json
+          smart-contract-action/scripts/templates/governance

--- a/action.yml
+++ b/action.yml
@@ -45,4 +45,4 @@ runs:
       with:
         name: ${{ github.job }}_proposals.zip
         path: |
-          smart-contract-action/scripts/templates/governance
+          smart-contract-action/scripts/templates/governance/

--- a/smart-contract-action/scripts/governance/instantiate-contract-filter.jq
+++ b/smart-contract-action/scripts/governance/instantiate-contract-filter.jq
@@ -1,7 +1,0 @@
-.proposer="$PROPOSER" |
-.content.title="$TITLE" |
-.content.description="$DESCRIPTION" |
-.content.run_as="$RUN_AS" |
-.content.admin="$ADMIN" |
-.content.code_id="$CODE_ID" |
-.content.label="$LABEL"

--- a/smart-contract-action/scripts/governance/migrate-contract-filter.jq
+++ b/smart-contract-action/scripts/governance/migrate-contract-filter.jq
@@ -1,5 +1,0 @@
-.proposer="$PROPOSER" |
-.content.title="$TITLE" |
-.content.description="$DESCRIPTION" |
-.content.contract="$CONTRACT_ADDRESS" |
-.content.code_id="$CODE_ID"

--- a/smart-contract-action/scripts/governance/wasm-store-filter.jq
+++ b/smart-contract-action/scripts/governance/wasm-store-filter.jq
@@ -1,5 +1,0 @@
-.proposer="$PROPOSER" |
-.content.title="$TITLE" |
-.content.description="$DESCRIPTION" |
-.content.run_as="$RUN_AS" |
-.content.instantiate_permission.address="$INSTANTIATE_ONLY_ADDRESS"

--- a/smart-contract-action/scripts/setup_provenance.sh
+++ b/smart-contract-action/scripts/setup_provenance.sh
@@ -16,30 +16,30 @@ export PIO_HOME
 export PROV_CMD
 
 if [ "$INIT_DATA" != false ]; then
-  # place the initial config data in the default location
-  echo "Setting initial data..."
+    # place the initial config data in the default location
+    echo "Setting initial data..."
 
-  cp -r "$INIT_DATA"/* $PIO_HOME
+    cp -r "$INIT_DATA"/* $PIO_HOME
 fi
 
 if [ ! -d "$PIO_HOME/config" ]; then
-  "$PROV_CMD" -t init --chain-id=testing testing
-  "$PROV_CMD" -t keys add validator --keyring-backend test
-  "$PROV_CMD" -t add-genesis-root-name validator pio --keyring-backend test
-  "$PROV_CMD" -t add-genesis-root-name validator pb --restrict=false \
-      --keyring-backend test
-  "$PROV_CMD" -t add-genesis-root-name validator io --restrict \
-      --keyring-backend test
-  "$PROV_CMD" -t add-genesis-root-name validator provenance \
-      --keyring-backend test
-  "$PROV_CMD" -t add-genesis-account validator 100000000000000000000nhash \
-      --keyring-backend test
-  "$PROV_CMD" -t gentx validator 1000000000000000nhash \
-      --keyring-backend test --chain-id=testing
-  "$PROV_CMD" -t add-genesis-marker 100000000000000000000nhash --manager \
-      validator --access mint,burn,admin,withdraw,deposit \
-      --activate --keyring-backend test
-  "$PROV_CMD" -t collect-gentxs
+    "$PROV_CMD" -t init --chain-id=testing testing
+    "$PROV_CMD" -t keys add validator --keyring-backend test
+    "$PROV_CMD" -t add-genesis-root-name validator pio --keyring-backend test
+    "$PROV_CMD" -t add-genesis-root-name validator pb --restrict=false \
+        --keyring-backend test
+    "$PROV_CMD" -t add-genesis-root-name validator io --restrict \
+        --keyring-backend test
+    "$PROV_CMD" -t add-genesis-root-name validator provenance \
+        --keyring-backend test
+    "$PROV_CMD" -t add-genesis-account validator 100000000000000000000nhash \
+        --keyring-backend test
+    "$PROV_CMD" -t gentx validator 1000000000000000nhash \
+        --keyring-backend test --chain-id=testing
+    "$PROV_CMD" -t add-genesis-marker 100000000000000000000nhash --manager \
+        validator --access mint,burn,admin,withdraw,deposit \
+        --activate --keyring-backend test
+    "$PROV_CMD" -t collect-gentxs
 fi
 
 nohup "$PROV_CMD" -t start &>/dev/null &
@@ -50,47 +50,19 @@ sleep 5s
 "$PROV_CMD" -t q marker holding nhash
 
 if [ "$TEST_SCRIPT" != false ]; then
-  # execute the script test that was passed in as an argument
-  echo "Executing test..."
+    # execute the script test that was passed in as an argument
+    echo "Executing test..."
 
-  $TEST_SCRIPT
+    $TEST_SCRIPT
 
-  echo "Test complete"
+    echo "Test complete"
 fi
 
 if [ "$GENERATE_PROPOSALS" != false ]; then
-  printf "\n\nGenerating proposals...\n\n"
+    printf "\n\nGenerating proposals...\n\n"
 
-  # create an account to generate the proposals since the sequence will always be 1
-  "$PROV_CMD" keys add proposal_generator --keyring-backend test --testnet --hd-path "44'/1'/0'/0/0"
+    $(base64 --wrap=0 $WASM_PATH > wasm_base64)
 
-  # generate and sanitize the store code proposal
-  "$PROV_CMD" tx gov submit-proposal wasm-store "$WASM_PATH" \
-    --title "title" \
-    --description "description" \
-    --run-as "$("$PROV_CMD" keys show -a proposal_generator --keyring-backend test --testnet)" \
-    --testnet \
-    --instantiate-only-address "$("$PROV_CMD" keys show -a proposal_generator --keyring-backend test --testnet)" \
-    --from "$("$PROV_CMD" keys show -a proposal_generator --keyring-backend test --testnet)" \
-    --generate-only \
-    --sequence 1 | jq '.body.messages[0]' | jq -f /scripts/governance/wasm-store-filter.jq > wasm-store-proposal.json
-
-  # generate and sanitize the instantiate code proposal
-  "$PROV_CMD" tx gov submit-proposal instantiate-contract 1 {} \
-    --title "title" \
-    --description "description" \
-    --label "label" \
-    --run-as "$("$PROV_CMD" keys show -a proposal_generator --keyring-backend test --testnet)" \
-    --admin "$("$PROV_CMD" keys show -a proposal_generator --keyring-backend test --testnet)"   --testnet \
-    --from "$("$PROV_CMD" keys show -a proposal_generator --keyring-backend test --testnet)" \
-    --generate-only \
-    --sequence 1 | jq '.body.messages[0]' | jq -f /scripts/governance/instantiate-contract-filter.jq > instantiate-contract-proposal.json
-
-  # generate and sanitize the migrate code proposal
-  "$PROV_CMD" tx gov submit-proposal migrate-contract \
-    "$("$PROV_CMD" keys show -a proposal_generator --keyring-backend test --testnet)" 1 {} \
-    --title title --description description \
-    --from "$("$PROV_CMD" keys show -a proposal_generator --keyring-backend test --testnet)" \
-    --generate-only \
-    --testnet --sequence 1 | jq '.body.messages[0]' | jq -f /scripts/governance/migrate-contract-filter.jq > migrate-contract-proposal.json
+    # generate and sanitize the store code proposal
+    awk 'NR==FNR{a=a""$0"\n";next} {while (match($0, /\$BYTE_CODE/)) {printf "%s", substr($0, 1, RSTART-1) a; $0 = substr($0, RSTART+RLENGTH)}; print}' wasm_base64 scripts/templates/governance/store/draft_proposal.json > scripts/templates/governance/store/draft_proposal.json
 fi

--- a/smart-contract-action/scripts/setup_provenance.sh
+++ b/smart-contract-action/scripts/setup_provenance.sh
@@ -64,5 +64,5 @@ if [ "$GENERATE_PROPOSALS" != false ]; then
     $(base64 --wrap=0 $WASM_PATH > wasm_base64)
 
     # generate and sanitize the store code proposal
-    awk 'NR==FNR{a=a""$0"\n";next} {while (match($0, /\$BYTE_CODE/)) {printf "%s", substr($0, 1, RSTART-1) a; $0 = substr($0, RSTART+RLENGTH)}; print}' wasm_base64 scripts/templates/governance/store/draft_proposal.json > scripts/templates/governance/store/draft_proposal.json
+    awk 'NR==FNR{a=a""$0"\n";next} {while (match($0, /\$BYTE_CODE/)) {printf "%s", substr($0, 1, RSTART-1) a; $0 = substr($0, RSTART+RLENGTH)}; print}' wasm_base64 templates/governance/store/draft_proposal.json > templates/governance/store/draft_proposal.json
 fi

--- a/smart-contract-action/scripts/setup_provenance.sh
+++ b/smart-contract-action/scripts/setup_provenance.sh
@@ -64,5 +64,6 @@ if [ "$GENERATE_PROPOSALS" != false ]; then
     $(base64 --wrap=0 $WASM_PATH > wasm_base64)
 
     # generate and sanitize the store code proposal
-    awk 'NR==FNR{a=a""$0"\n";next} {while (match($0, /\$BYTE_CODE/)) {printf "%s", substr($0, 1, RSTART-1) a; $0 = substr($0, RSTART+RLENGTH)}; print}' wasm_base64 templates/governance/store/draft_proposal.json > templates/governance/store/draft_proposal.json
+    awk 'NR==FNR{a=a""$0"\n";next} {while (match($0, /\$BYTE_CODE/)) {printf "%s", substr($0, 1, RSTART-1) a; $0 = substr($0, RSTART+RLENGTH)}; print}' wasm_base64 smart-contract-action/scripts/templates/governance/store/draft_proposal.json > temp_store_proposal
+    mv temp_store_proposal smart-contract-action/scripts/templates/governance/store/draft_proposal.json
 fi

--- a/smart-contract-action/scripts/templates/governance/instantiate/draft_metadata.json
+++ b/smart-contract-action/scripts/templates/governance/instantiate/draft_metadata.json
@@ -1,0 +1,8 @@
+{
+    "title": "$TITLE",
+    "authors": "$AUTHOR",
+    "summary": "$SUMMARY",
+    "details": "$DETAILS",
+    "proposal_forum_url": "$FORUM_URL",
+    "vote_option_context": "$VOTE_OPTION_CONTEXT"
+}

--- a/smart-contract-action/scripts/templates/governance/instantiate/draft_proposal.json
+++ b/smart-contract-action/scripts/templates/governance/instantiate/draft_proposal.json
@@ -1,0 +1,15 @@
+{
+    "messages": [
+        {
+            "@type": "/cosmwasm.wasm.v1.MsgInstantiateContract",
+            "sender": "$SENDER_BECH32_ADDRESS",
+            "admin": "$ADMIN_BECH32_ADDRESS",
+            "code_id": "$CODE_ID",
+            "label": "$LABEL",
+            "msg": null,
+            "funds": []
+        }
+    ],
+    "metadata": "ipfs://$CID",
+    "deposit": "$DEPOSIT"
+}

--- a/smart-contract-action/scripts/templates/governance/migrate/draft_metadata.json
+++ b/smart-contract-action/scripts/templates/governance/migrate/draft_metadata.json
@@ -1,0 +1,8 @@
+{
+    "title": "$TITLE",
+    "authors": "$AUTHOR",
+    "summary": "$SUMMARY",
+    "details": "$DETAILS",
+    "proposal_forum_url": "$FORUM_URL",
+    "vote_option_context": "$VOTE_OPTION_CONTEXT"
+}

--- a/smart-contract-action/scripts/templates/governance/migrate/draft_proposal.json
+++ b/smart-contract-action/scripts/templates/governance/migrate/draft_proposal.json
@@ -1,0 +1,13 @@
+{
+    "messages": [
+        {
+            "@type": "/cosmwasm.wasm.v1.MsgMigrateContract",
+            "sender": "$SENDER_BECH32_ADDRESS",
+            "contract": "$CONTRACT_BECH32_ADDRESS",
+            "code_id": "$CODE_ID",
+            "msg": null
+        }
+    ],
+    "metadata": "ipfs://CID",
+    "deposit": "DEPOSIT"
+}

--- a/smart-contract-action/scripts/templates/governance/store/draft_metadata.json
+++ b/smart-contract-action/scripts/templates/governance/store/draft_metadata.json
@@ -1,0 +1,8 @@
+{
+    "title": "$TITLE",
+    "authors": "$AUTHOR",
+    "summary": "$SUMMARY",
+    "details": "$DETAILS",
+    "proposal_forum_url": "$FORUM_URL",
+    "vote_option_context": "$VOTE_OPTION_CONTEXT"
+}

--- a/smart-contract-action/scripts/templates/governance/store/draft_proposal.json
+++ b/smart-contract-action/scripts/templates/governance/store/draft_proposal.json
@@ -1,0 +1,12 @@
+{
+    "messages": [
+        {
+            "@type": "/cosmwasm.wasm.v1.MsgStoreCode",
+            "sender": "$SENDER_BECH32_ADDRESS",
+            "wasm_byte_code": "$BYTE_CODE",
+            "instantiate_permission": null
+        }
+    ],
+    "metadata": "ipfs://CID",
+    "deposit": "$DEPOSIT"
+}


### PR DESCRIPTION
This PR updates the smart contract proposal generation to use the new format. It uses built-in templates and includes the base64 encoded wasm byte code in the store proposal.

As before, the developer will need to substitute the values in the proposals with their own (addresses, details, forum url, json payloads, etc).

This closes #7 